### PR TITLE
Build process update - Combine Makefile with Docker Compose

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@
 # dependencies within the image, ensuring a consistent and reproducible environment across
 # various workstations.
 #
-# == Prerequisites
+# === Prerequisites
 #
 # Having Visual Studio Code (VSCode) and the Dev Container plugin installed are
 # essential prerequisites for this development environment. This devcontainer has
@@ -25,8 +25,7 @@
 # inside the devcontainer and initializes ``pre-commit`` once the container is created.
 #
 # [source, json]
-#
-# ....
+# ```
 # {
 # 	"name": "sommerfeld-io",
 #   "build": {
@@ -39,7 +38,7 @@
 #
 # 	"postCreateCommand": "pre-commit install"
 # }
-# ....
+# ```
 
 
 FROM mcr.microsoft.com/devcontainers/javascript-node:20-bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 	},
 
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:2.7.1": {}
 	},
 
 	"postCreateCommand": "pre-commit install"

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 .vscode
 docs
 ui/material-admin-pro/template
+ui/material-admin-pro/ui-bundle/Dockerfile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: docker
+    directory: ui/material-admin-pro/ui-bundle/Dockerfile
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,36 @@ permissions:
   contents: read
 
 jobs:
-  website-docker-image:
+  ui-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ui/material-admin-pro/ui-bundle/Dockerfile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Docker image build
+        uses: docker/build-push-action@v5
+        with:
+          context: ui/material-admin-pro/ui-bundle
+          platforms: linux/amd64
+          push: false
+          tags: local/ui-preview:dev
+
+  website:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,6 +75,16 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install gulp-cli
+        run: npm install --location=global gulp-cli@2.3.0
+        shell: bash
+      - name: Build UI bundle
+        run: make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip
+        shell: bash
       - name: Set docker tag
         id: vars
         run: |
@@ -108,27 +147,9 @@ jobs:
           exit-code: ${{ github.event_name == 'pull_request' }}
           write-comment: ${{ github.event_name == 'pull_request' }}
 
-  ui-bundle:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Install gulp-cli
-        run: npm install --location=global gulp-cli@2.3.0
-        shell: bash
-      - name: Build UI bundle
-        run: make build-ui
-        shell: bash
-
   on-failure:
     runs-on: ubuntu-latest
-    needs: ['website-docker-image', 'ui-bundle']
+    needs: ['website', 'ui-preview']
     if: failure()
     steps:
       - name: Send Pipeline Status to Google Chat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./README.md
       - name: Build UI bundle
-        run: make build-ui
+        run: make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip
         shell: bash
       - name: Create tag and Github release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,15 @@
 # components. The main purpose of this Dockerfile is to generate the documentation sites using
 # link:https://www.antora.org[Antora].
 #
-# == Prerequisites
+# === Prerequisites
 #
 # This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 #
-# == About the tags and versions
+# === About the tags and versions
 #
 # include::ROOT:partial$/docker-tag-strategy.adoc[]
 #
-# === How to use
+# == How to use
 #
 # Use ``docker run --rm -p "7888:7888" sommerfeldio/website:rc`` to run the moist recent release
 # candidate from DockerHub.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,27 +6,21 @@
 # components. The main purpose of this Dockerfile is to generate the documentation sites using
 # link:https://www.antora.org[Antora].
 #
-# Once all sites are built, the last stage of this multistage image starts an Apache server, making
-# the website accessible over HTTP.
-#
 # == Prerequisites
 #
-# This image has been developed and tested with Docker version 24.0.2 on top of Ubuntu 22.10.
+# This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 #
 # == About the tags and versions
 #
 # include::ROOT:partial$/docker-tag-strategy.adoc[]
 #
-# === Example
+# === How to use
 #
-# Use the xref:AUTO-GENERATED:build-and-run-website-sh.adoc[``build-and-run-website.sh``] script
-# to build this image and start a container. The script basically invokes these two commands.
+# Use ``docker run --rm -p "7888:7888" sommerfeldio/website:rc`` to run the moist recent release
+# candidate from DockerHub.
 #
-# [source, bash]
-# ```
-# docker build --no-cache -t local/website:dev .
-# docker run --rm -p "7888:7888" local/website:dev
-# ```
+# The most effective method to construct and operate the website on a local machine is by using
+# the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
 #
 # == Image Structure
 #
@@ -40,19 +34,11 @@
 # combines the content with the UI bundle to generate the final website, ensuring consistency in design
 # and layout throughout the site.
 #
-# The Google font "Poppins" (https://www.npmjs.com/package/@expo-google-fonts/poppins?activeTab=readme)
-# is now part of the ``package.json``. The Dockerfile takes care of copying the fonts from
-# ``ui/material-admin-pro/ui-bundle/node_modules/@expo-google-fonts`` to ``ui/material-admin-pro/ui-bundle/src/font``.
+# IMPORTANT: Make sure to control local image builds by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
+# The ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`` is a mandatory prerequisite. Otherwise
+# The build breaks due to a missing UI bundle.
 #
-# The ``build-ui-bundle`` stage leverages link:https://antora.org[Antora], a documentation site generator,
-# to build the documentation sites of the website. Antora allows the documentation to be sourced from
-# different repositories, making it easier to manage and update documentation across various projects.
-# The configuration for Antora can be found in the ``config/playbooks`` folder. The contents from all
-# repos are cloned from GitHub because (a) project files from the local machine filesystem (the docker-host)
-# are not present inside container and (b) maybe not all relevant repositories are cloned on the local
-# workstation, making it impossible to mount everything into the container.
-#
-# Once all the sites are built, the ``run`` stage of the image initiates an HTTP server using the Docker
+# Once all pages are built, the ``run`` stage of the image initiates an HTTP server using the Docker
 # image link:https://hub.docker.com/_/httpd[httpd]. This HTTP server makes the entire website accessible
 # over HTTP. The resulting image from this stage only includes the built files needed for serving the
 # website, avoiding any unnecessary dependencies or intermediate build artifacts from previous stages.
@@ -68,29 +54,6 @@
 # The webserver exposes his status information through http://localhost:7888/server-status.
 
 
-FROM node:21-bullseye-slim AS build-ui-bundle
-LABEL maintainer="sebastian@sommerfeld.io"
-
-RUN yarn global add gulp-cli@2.3.0 \
-    && yarn global add @antora/cli@3.1 \
-    && yarn global add @antora/site-generator@3.1
-
-COPY ui/material-admin-pro/ui-bundle /antora-ui
-
-WORKDIR /antora-ui
-
-RUN yarn install \
-    && mkdir -p src/font \
-    && cp node_modules/@fontsource/roboto/files/roboto-*.woff* src/font \
-    && cp node_modules/@fontsource/roboto-mono/files/roboto-mono-*.woff* src/font \
-    && cp node_modules/@fontsource/material-icons/files/material-icons-*.woff* src/font \
-    && cp node_modules/@fontsource/material-icons-outlined/files/material-icons-*.woff* src/font \
-    && cp node_modules/@fontsource/material-icons-round/files/material-icons-*.woff* src/font \
-    && cp node_modules/@fontsource/material-icons-sharp/files/material-icons-*.woff* src/font \
-    && cp node_modules/@fontsource/material-icons-two-tone/files/material-icons-*.woff* src/font \
-    && gulp bundle
-
-
 FROM antora/antora:3.1.5 AS build-antora-site
 LABEL maintainer="sebastian@sommerfeld.io"
 
@@ -98,7 +61,7 @@ RUN yarn add @asciidoctor/core@~3.0.2 \
     && yarn add asciidoctor-kroki@~0.18.1 \
     && yarn add @antora/lunr-extension@~1.0.0-alpha.8
 
-COPY --from=build-ui-bundle /antora-ui/build/ui-bundle.zip /antora-ui/material-admin-pro/ui-bundle.zip
+COPY ui/material-admin-pro/ui-bundle/build/ui-bundle.zip /antora-ui/material-admin-pro/ui-bundle.zip
 COPY config /antora
 WORKDIR /antora
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@
 # combines the content with the UI bundle to generate the final website, ensuring consistency in design
 # and layout throughout the site.
 #
-# IMPORTANT: Make sure to control local image builds by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
-# The ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`` is a mandatory prerequisite. Otherwise
-# The build breaks due to a missing UI bundle.
+# IMPORTANT: Make sure to control the image builds and containers by using the
+# xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The
+# ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`` is a mandatory
+# prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+# missing UI bundle.
 #
 # Once all pages are built, the ``run`` stage of the image initiates an HTTP server using the Docker
 # image link:https://hub.docker.com/_/httpd[httpd]. This HTTP server makes the entire website accessible

--- a/Makefile
+++ b/Makefile
@@ -2,85 +2,45 @@
 # @brief Build the website from its source files and run the website within a Docker container.
 #
 # @description This Makefile streamlines the process of building the website from its
-# source files and orchestrating its execution within a Docker container.
+# source files and orchestrating its execution within Docker containers.
 #
 # == How to use this Makefile
 #
-# The default target, which is triggered when simply using ``make`` combines ``make build``
-# and ``make run``.
-#
-# === ``make build``
-#
-# Automates the process of creating a Docker image that encapsulates the entire
-# link:https://www.sommerfeld.io[sommerfeld-io website] within an Apache httpd web server. The
-# website is built with Antora first. This target simplifies the setup and configuration required
-# to run the website locally. The image is based on the official link:https://hub.docker.com/_/httpd[Apache httpd]
-# image.
-#
-# Per default, Apache httpd runs as ``root`` user because only root processes can listen to ports
-# below 1024. The default http port for web applications is 80. But this means the user inside the
-# container is ``root`` which poses a potential security risk. And since the webserver is running
-# inside a Docker container it is not important what port is used inside the container. So the http
-# port is changed to 7888 and the user is switched to the already present user ``www-data``.
-#
-# Apache is trying to write a file into ``/usr/local/apache2/logs``, but the ``www-data`` user does
-# not have permission to create files in this directory. So permissions to this directory are
-# updated as well.
-#
-# | Image                 | Port | Protocol |
-# | --------------------- | ---- | -------- |
-# | ``local/website:dev`` | 7888 | http     |
-#
-# The image is intended for local testing purposes. For production use, take a look at the
-# link:https://hub.docker.com/r/sommerfeldio/website[``sommerfeldio/website``] image on
-# Dockerhub.
+# The default target, which is triggered when simply using ``make`` installs all dependencies,
+# builds the UI bundle and starts all Docker containers by invoking ``make run``.
 #
 # === ``make run``
 #
 # Launches a Docker container based on the newly created image. The container is started in the
 # foreground. The locally hosted website can be accessed via a web browser at http://localhost:7888.
 #
-# === ``make build-ui``
+# === ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip``
 #
 # Automates the process of building the Antora UI bundle. Use this target from a Github Actions
-# workflow to build the UI bundle from a pipeline. This target does not start up a webserver to
-# preview the UI bundle in a browser.
-#
-# === ``make preview-ui``
-#
-# Run a local preview of the documentation site using the UI bundle. The preview uses demo
-# content from the ``preview-src`` folder for testing and development purposes. The UI bundle
-# preview is available through http://localhost:5252. This target uses ``make build-ui``
-# as a prerequisites.
-#
-# === ``make preview-template``
-#
-# Exposes the HTML template through a webserver on http://localhost:5353.
+# workflow to build the UI bundle from a pipeline.
 #
 # === ``make clean``
 #
-# Remove the local Docker image
-#
-# === ``make all``
-#
-# This phony target triggers all build-related targets (``make build-ui`` and ``make build``)
+# Remove local Docker images, dependencies and build artifacts.
 #
 # == Prerequisites
 #
 # This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
-# prerequisites on your host, open the project in the devcontainer from this repo. Python3
-# is needed as well. The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer]
-# for this repository ships all these depencencies.
+# prerequisites on your host, open the project in the DevContainer from this repo. This project
+# has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+# The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
+# all these depencencies.
 
 
-WEBSITE_DOCKER_IMAGE = "local/website:dev"
-WEBSITE_PORT = 7888
-TEMPLATE_PORT = 5353
+UI_SRC_DIR = ui/material-admin-pro/ui-bundle
+NODE_MODULES = $(UI_SRC_DIR)/node_modules
+FONTS = $(UI_SRC_DIR)/src/font
+UI_BUNDLE_ZIP = $(UI_SRC_DIR)/build/ui-bundle.zip
 
 .DEFAULT_GOAL := run
-.PHONY: all clean test build run install build-ui preview-ui preview-template lint-makefile lint-yaml lint-folders lint-filenames
+.PHONY: all clean build-ui run lint-makefile lint-yaml lint-folders lint-filenames test
 
-all: build-ui build
+all: build-ui clean
 
 lint-makefile:
 	docker run --rm --volume "$(shell pwd):/data" cytopia/checkmake:latest Makefile
@@ -97,37 +57,37 @@ lint-filenames:
 test: lint-makefile lint-yaml lint-folders lint-filenames
 	docker run --rm -i hadolint/hadolint:latest < Dockerfile
 
-build: test
-	@echo "[INFO] Build Docker image $(WEBSITE_DOCKER_IMAGE)"
-	docker build --no-cache -t "$(WEBSITE_DOCKER_IMAGE)" .
-
-run: build
-	@echo "[INFO] Run Docker image"
-	docker run --rm mwendler/figlet:latest "$(WEBSITE_PORT)"
-	docker run --rm -p "$(WEBSITE_PORT):7888" "$(WEBSITE_DOCKER_IMAGE)"
-
-install:
-	@cd ui/material-admin-pro/ui-bundle || exit \
+$(NODE_MODULES):
+	@cd $(UI_SRC_DIR) || exit \
 		&& yarn install
 
-build-ui: install
-	@cd ui/material-admin-pro/ui-bundle || exit \
+$(FONTS): $(NODE_MODULES)
+	@cd $(UI_SRC_DIR) || exit \
+		&& mkdir -p src/font \
+		&& cp node_modules/@fontsource/roboto/files/roboto-*.woff* src/font \
+		&& cp node_modules/@fontsource/roboto-mono/files/roboto-mono-*.woff* src/font \
+		&& cp node_modules/@fontsource/material-icons/files/material-icons-*.woff* src/font \
+		&& cp node_modules/@fontsource/material-icons-outlined/files/material-icons-*.woff* src/font \
+		&& cp node_modules/@fontsource/material-icons-round/files/material-icons-*.woff* src/font \
+		&& cp node_modules/@fontsource/material-icons-sharp/files/material-icons-*.woff* src/font \
+		&& cp node_modules/@fontsource/material-icons-two-tone/files/material-icons-*.woff* src/font
+
+$(UI_BUNDLE_ZIP): $(FONTS)
+	@cd $(UI_SRC_DIR) || exit \
 		&& gulp bundle
 
-preview-ui: build-ui
-	@cd ui/material-admin-pro/ui-bundle || exit \
-		&& gulp preview
-
-preview-template:
-	@cd ui/material-admin-pro/template/pages || exit \
-		&& docker run --rm mwendler/figlet:latest $(TEMPLATE_PORT) \
-		&& python3 -m http.server $(TEMPLATE_PORT)
+run: test $(UI_BUNDLE_ZIP)
+	docker compose build --no-cache
+	docker compose up
 
 clean:
-	@echo "[INFO] Remove old versions of $(WEBSITE_DOCKER_IMAGE)"
-	docker image rm "$(WEBSITE_DOCKER_IMAGE)"
+	@echo "[INFO] Remove containers"
+	docker compose down --rmi all --volumes --remove-orphans
+
+	@echo "[INFO] Remove fonts"
+	rm -rf $(FONTS)
 
 	@echo "[INFO] Cleanup local filesystem"
-	rm -rf ui/material-admin-pro/ui-bundle/build
-	rm -rf ui/material-admin-pro/ui-bundle/node_modules
-	rm -rf ui/material-admin-pro/ui-bundle/public
+	rm -rf $(UI_BUNDLE_ZIP)
+	rm -rf $(NODE_MODULES)
+	rm -rf $(UI_SRC_DIR)/public

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@
 # has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 # The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
 # all these depencencies.
+#
+# == See also
+#
+# * xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]
+# * xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]
+# * xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]
 
 
 UI_SRC_DIR = ui/material-admin-pro/ui-bundle

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 # @description This Makefile streamlines the process of building the website from its
 # source files and orchestrating its execution within Docker containers.
 #
+# === Prerequisites
+#
+# This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
+# prerequisites on your host, open the project in the DevContainer from this repo. This project
+# has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+# The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
+# all these depencencies.
+#
 # == How to use this Makefile
 #
 # The default target, which is triggered when simply using ``make`` installs all dependencies,
@@ -11,25 +19,19 @@
 #
 # === ``make run``
 #
-# Launches a Docker container based on the newly created image. The container is started in the
-# foreground. The locally hosted website can be accessed via a web browser at http://localhost:7888.
+# Start all Docker containers for local development. Installing and buindling dependencies
+# are triggered automatically if needed. Take a look at xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]
+# for further information on the started Docker containers.
 #
 # === ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip``
 #
 # Automates the process of building the Antora UI bundle. Use this target from a Github Actions
-# workflow to build the UI bundle from a pipeline.
+# workflow to build the UI bundle from a pipeline. Installing dependencies is triggered
+# automatically if needed.
 #
 # === ``make clean``
 #
 # Remove local Docker images, dependencies and build artifacts.
-#
-# == Prerequisites
-#
-# This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
-# prerequisites on your host, open the project in the DevContainer from this repo. This project
-# has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
-# The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
-# all these depencencies.
 #
 # == See also
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 ---
 # @file docker-compose.yml
-# @brief ...
+# @brief Docker Compose configuration to build and start all Docker containers required for local development.
 #
-# @description This Docker Compose configuration serves the purpose of buildind and starting all
+# @description This Docker Compose configuration serves the purpose of building and starting all
 # the essential Docker containers required to facilitate the local development of both the website
 # and the UI bundle. This configuration orchestrates this by starting multiple containers
 # simultaneously. Each container within this Compose configuration corresponds to a distinct
@@ -14,19 +14,18 @@
 # | ``local/ui-preview:dev``    | 5252 | http     | UI bundle preview for local development (see xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]) |
 # | ``httpd:2.4.58-alpine3.18`` | 5353 | http     | Serve the static HTML template files, which form the foundation of the UI bundle (and hence the whole website UI) through an Apache webserver. |
 #
+# === Prerequisites
+#
+# This compose config has been developed and tested with Docker version 24.0.2 on top of
+# Ubuntu 22.10.
+#
 # == How to Use
 #
-# Make sure to control the image builds and containers by using the
-# xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip``
-# is a mandatory prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+# Make sure to control the image builds and containers by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
+#
+# The ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`` is a mandatory prerequisite
+# (which the Makefile ensures). Otherwise the build breaks due to a
 # missing UI bundle.
-#
-# See xref:AUTO-GENERATED:Makefile.adoc[Makefile]
-#
-# == Prerequisites
-#
-# This compose config has been developed and tested with Docker version 24.0.2 on top
-# of Ubuntu 22.10.
 
 
 version: "3.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+---
+# @file docker-compose.yml
+# @brief ...
+#
+# @description ...
+# todo ... write description and brief (above)
+#
+# == Prerequisites
+#
+# This compose config has been developed and tested with Docker version 24.0.2 on top
+# of Ubuntu 22.10.
+#
+# == How to use
+#
+# todo ... at least update the image names below
+#
+# == See also
+#
+# * xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]
+
+
+version: "3.3"
+services:
+
+  ui-preview:
+    container_name: ui-preview
+    build: ui/material-admin-pro/ui-bundle
+    image: local/ui-preview:dev
+    ports:
+      - 5252:5252
+    volumes:
+      - ./ui/material-admin-pro/ui-bundle:/ui-bundle
+
+  website:
+    container_name: website
+    build: .
+    image: local/website:dev
+    ports:
+      - 7888:7888
+    depends_on:
+      - ui-preview
+
+  template:
+    container_name: template
+    image: httpd:2.4.58-alpine3.18
+    ports:
+      - 5353:80
+    volumes:
+      - ./ui/material-admin-pro/template/pages:/usr/local/apache2/htdocs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,31 @@
 # @file docker-compose.yml
 # @brief ...
 #
-# @description ...
-# todo ... write description and brief (above)
+# @description This Docker Compose configuration serves the purpose of buildind and starting all
+# the essential Docker containers required to facilitate the local development of both the website
+# and the UI bundle. This configuration orchestrates this by starting multiple containers
+# simultaneously. Each container within this Compose configuration corresponds to a distinct
+# component or service of the development environment.
+#
+# | Image                       | Port | Protocol | Info                                        |
+# | --------------------------- | ---- | -------- | ------------------------------------------- |
+# | ``local/website:dev``       | 7888 | http     | Antora-generated website with real contents (see xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]) |
+# | ``local/ui-preview:dev``    | 5252 | http     | UI bundle preview for local development (see xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]) |
+# | ``httpd:2.4.58-alpine3.18`` | 5353 | http     | Serve the static HTML template files, which form the foundation of the UI bundle (and hence the whole website UI) through an Apache webserver. |
+#
+# == How to Use
+#
+# Make sure to control the image builds and containers by using the
+# xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The ``make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip``
+# is a mandatory prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+# missing UI bundle.
+#
+# See xref:AUTO-GENERATED:Makefile.adoc[Makefile]
 #
 # == Prerequisites
 #
 # This compose config has been developed and tested with Docker version 24.0.2 on top
 # of Ubuntu 22.10.
-#
-# == How to use
-#
-# todo ... at least update the image names below
-#
-# == See also
-#
-# * xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]
 
 
 version: "3.3"

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: website
 title: Sommerfeld.io Website
-version: main
+version: build-process-update
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/AUTO-GENERATED/pages/-devcontainer/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/-devcontainer/Dockerfile.adoc
@@ -9,7 +9,7 @@ specifically for the project. It serves as the foundation for encapsulating all 
 dependencies within the image, ensuring a consistent and reproducible environment across
 various workstations.
 
-== Prerequisites
+=== Prerequisites
 
 Having Visual Studio Code (VSCode) and the Dev Container plugin installed are
 essential prerequisites for this development environment. This devcontainer has
@@ -29,7 +29,7 @@ inside the devcontainer and initializes `pre-commit` once the container is creat
 
 [source, json]
 
-....
+----
 {
 "name": "sommerfeld-io",
 "build": {
@@ -42,4 +42,4 @@ inside the devcontainer and initializes `pre-commit` once the container is creat
 
 "postCreateCommand": "pre-commit install"
 }
-....
+----

--- a/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
@@ -9,28 +9,21 @@ link:https://www.sommerfeld.io[www.sommerfeld.io] website by integrating and bui
 components. The main purpose of this Dockerfile is to generate the documentation sites using
 link:https://www.antora.org[Antora].
 
-Once all sites are built, the last stage of this multistage image starts an Apache server, making
-the website accessible over HTTP.
-
 == Prerequisites
 
-This image has been developed and tested with Docker version 24.0.2 on top of Ubuntu 22.10.
+This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 
 == About the tags and versions
 
 include::ROOT:partial$/docker-tag-strategy.adoc[]
 
-=== Example
+=== How to use
 
-Use the xref:AUTO-GENERATED:build-and-run-website-sh.adoc[`build-and-run-website.sh`] script
-to build this image and start a container. The script basically invokes these two commands.
+Use `docker run --rm -p "7888:7888" sommerfeldio/website:rc` to run the moist recent release
+candidate from DockerHub.
 
-[source, bash]
-
-----
-docker build --no-cache -t local/website:dev .
-docker run --rm -p "7888:7888" local/website:dev
-----
+The most effective method to construct and operate the website on a local machine is by using
+the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
 
 == Image Structure
 
@@ -44,19 +37,11 @@ built, it can serve as the foundation upon which the actual website content is a
 combines the content with the UI bundle to generate the final website, ensuring consistency in design
 and layout throughout the site.
 
-The Google font "Poppins" (https://www.npmjs.com/package/@expo-google-fonts/poppins?activeTab=readme)
-is now part of the `package.json`. The Dockerfile takes care of copying the fonts from
-`ui/material-admin-pro/ui-bundle/node_modules/@expo-google-fonts` to `ui/material-admin-pro/ui-bundle/src/font`.
+IMPORTANT: Make sure to control local image builds by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
+The `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip` is a mandatory prerequisite. Otherwise
+The build breaks due to a missing UI bundle.
 
-The `build-ui-bundle` stage leverages link:https://antora.org[Antora], a documentation site generator,
-to build the documentation sites of the website. Antora allows the documentation to be sourced from
-different repositories, making it easier to manage and update documentation across various projects.
-The configuration for Antora can be found in the `config/playbooks` folder. The contents from all
-repos are cloned from GitHub because (a) project files from the local machine filesystem (the docker-host)
-are not present inside container and (b) maybe not all relevant repositories are cloned on the local
-workstation, making it impossible to mount everything into the container.
-
-Once all the sites are built, the `run` stage of the image initiates an HTTP server using the Docker
+Once all pages are built, the `run` stage of the image initiates an HTTP server using the Docker
 image link:https://hub.docker.com/_/httpd[httpd]. This HTTP server makes the entire website accessible
 over HTTP. The resulting image from this stage only includes the built files needed for serving the
 website, avoiding any unnecessary dependencies or intermediate build artifacts from previous stages.

--- a/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
@@ -9,15 +9,15 @@ link:https://www.sommerfeld.io[www.sommerfeld.io] website by integrating and bui
 components. The main purpose of this Dockerfile is to generate the documentation sites using
 link:https://www.antora.org[Antora].
 
-== Prerequisites
+=== Prerequisites
 
 This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 
-== About the tags and versions
+=== About the tags and versions
 
 include::ROOT:partial$/docker-tag-strategy.adoc[]
 
-=== How to use
+== How to use
 
 Use `docker run --rm -p "7888:7888" sommerfeldio/website:rc` to run the moist recent release
 candidate from DockerHub.

--- a/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Dockerfile.adoc
@@ -37,9 +37,11 @@ built, it can serve as the foundation upon which the actual website content is a
 combines the content with the UI bundle to generate the final website, ensuring consistency in design
 and layout throughout the site.
 
-IMPORTANT: Make sure to control local image builds by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
-The `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip` is a mandatory prerequisite. Otherwise
-The build breaks due to a missing UI bundle.
+IMPORTANT: Make sure to control the image builds and containers by using the
+xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The
+`make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip` is a mandatory
+prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+missing UI bundle.
 
 Once all pages are built, the `run` stage of the image initiates an HTTP server using the Docker
 image link:https://hub.docker.com/_/httpd[httpd]. This HTTP server makes the entire website accessible

--- a/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
@@ -5,76 +5,31 @@ Build the website from its source files and run the website within a Docker cont
 == Overview
 
 This Makefile streamlines the process of building the website from its
-source files and orchestrating its execution within a Docker container.
+source files and orchestrating its execution within Docker containers.
 
 == How to use this Makefile
 
-The default target, which is triggered when simply using `make` combines `make build`
-and `make run`.
-
-=== `make build`
-
-Automates the process of creating a Docker image that encapsulates the entire
-link:https://www.sommerfeld.io[sommerfeld-io website] within an Apache httpd web server. The
-website is built with Antora first. This target simplifies the setup and configuration required
-to run the website locally. The image is based on the official link:https://hub.docker.com/_/httpd[Apache httpd]
-image.
-
-Per default, Apache httpd runs as `root` user because only root processes can listen to ports
-below 1024. The default http port for web applications is 80. But this means the user inside the
-container is `root` which poses a potential security risk. And since the webserver is running
-inside a Docker container it is not important what port is used inside the container. So the http
-port is changed to 7888 and the user is switched to the already present user `www-data`.
-
-Apache is trying to write a file into `/usr/local/apache2/logs`, but the `www-data` user does
-not have permission to create files in this directory. So permissions to this directory are
-updated as well.
-
-|===
-| Image | Port | Protocol
-
-| `local/website:dev`
-| 7888
-| http
-|===
-
-The image is intended for local testing purposes. For production use, take a look at the
-link:https://hub.docker.com/r/sommerfeldio/website[`sommerfeldio/website`] image on
-Dockerhub.
+The default target, which is triggered when simply using `make` installs all dependencies,
+builds the UI bundle and starts all Docker containers by invoking `make run`.
 
 === `make run`
 
 Launches a Docker container based on the newly created image. The container is started in the
 foreground. The locally hosted website can be accessed via a web browser at http://localhost:7888.
 
-=== `make build-ui`
+=== `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`
 
 Automates the process of building the Antora UI bundle. Use this target from a Github Actions
-workflow to build the UI bundle from a pipeline. This target does not start up a webserver to
-preview the UI bundle in a browser.
-
-=== `make preview-ui`
-
-Run a local preview of the documentation site using the UI bundle. The preview uses demo
-content from the `preview-src` folder for testing and development purposes. The UI bundle
-preview is available through http://localhost:5252. This target uses `make build-ui`
-as a prerequisites.
-
-=== `make preview-template`
-
-Exposes the HTML template through a webserver on http://localhost:5353.
+workflow to build the UI bundle from a pipeline.
 
 === `make clean`
 
-Remove the local Docker image
-
-=== `make all`
-
-This phony target triggers all build-related targets (`make build-ui` and `make build`)
+Remove local Docker images, dependencies and build artifacts.
 
 == Prerequisites
 
 This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
-prerequisites on your host, open the project in the devcontainer from this repo. Python3
-is needed as well. The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer]
-for this repository ships all these depencencies.
+prerequisites on your host, open the project in the DevContainer from this repo. This project
+has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
+all these depencencies.

--- a/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
@@ -33,3 +33,9 @@ prerequisites on your host, open the project in the DevContainer from this repo.
 has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
 all these depencencies.
+
+== See also
+
+* xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]
+* xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]
+* xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]

--- a/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/Makefile.adoc
@@ -7,6 +7,14 @@ Build the website from its source files and run the website within a Docker cont
 This Makefile streamlines the process of building the website from its
 source files and orchestrating its execution within Docker containers.
 
+=== Prerequisites
+
+This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
+prerequisites on your host, open the project in the DevContainer from this repo. This project
+has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
+all these depencencies.
+
 == How to use this Makefile
 
 The default target, which is triggered when simply using `make` installs all dependencies,
@@ -14,25 +22,19 @@ builds the UI bundle and starts all Docker containers by invoking `make run`.
 
 === `make run`
 
-Launches a Docker container based on the newly created image. The container is started in the
-foreground. The locally hosted website can be accessed via a web browser at http://localhost:7888.
+Start all Docker containers for local development. Installing and buindling dependencies
+are triggered automatically if needed. Take a look at xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]
+for further information on the started Docker containers.
 
 === `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`
 
 Automates the process of building the Antora UI bundle. Use this target from a Github Actions
-workflow to build the UI bundle from a pipeline.
+workflow to build the UI bundle from a pipeline. Installing dependencies is triggered
+automatically if needed.
 
 === `make clean`
 
 Remove local Docker images, dependencies and build artifacts.
-
-== Prerequisites
-
-This Makefile needs Node, NPM and Gulp installed. To avoid having to install all
-prerequisites on your host, open the project in the DevContainer from this repo. This project
-has been developed in VSCode and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
-The xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[DevContainer] for this repository ships
-all these depencencies.
 
 == See also
 

--- a/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
@@ -1,0 +1,21 @@
+= docker-compose.yml
+
+...
+
+== Overview
+
+...
+todo ... write description and brief (above)
+
+== Prerequisites
+
+This compose config has been developed and tested with Docker version 24.0.2 on top
+of Ubuntu 22.10.
+
+== How to use
+
+todo ... at least update the image names below
+
+== See also
+
+* xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]

--- a/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
@@ -4,18 +4,41 @@
 
 == Overview
 
-...
-todo ... write description and brief (above)
+This Docker Compose configuration serves the purpose of buildind and starting all
+the essential Docker containers required to facilitate the local development of both the website
+and the UI bundle. This configuration orchestrates this by starting multiple containers
+simultaneously. Each container within this Compose configuration corresponds to a distinct
+component or service of the development environment.
+
+|===
+| Image | Port | Protocol | Info
+
+| `local/website:dev`
+| 7888
+| http
+| Antora-generated website with real contents (see xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile])
+
+| `local/ui-preview:dev`
+| 5252
+| http
+| UI bundle preview for local development (see xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile])
+
+| `httpd:2.4.58-alpine3.18`
+| 5353
+| http
+| Serve the static HTML template files, which form the foundation of the UI bundle (and hence the whole website UI) through an Apache webserver.
+|===
+
+== How to Use
+
+Make sure to control the image builds and containers by using the
+xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`
+is a mandatory prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+missing UI bundle.
+
+See xref:AUTO-GENERATED:Makefile.adoc[Makefile]
 
 == Prerequisites
 
 This compose config has been developed and tested with Docker version 24.0.2 on top
 of Ubuntu 22.10.
-
-== How to use
-
-todo ... at least update the image names below
-
-== See also
-
-* xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]

--- a/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/docker-compose-yml.adoc
@@ -1,10 +1,10 @@
 = docker-compose.yml
 
-...
+Docker Compose configuration to build and start all Docker containers required for local development.
 
 == Overview
 
-This Docker Compose configuration serves the purpose of buildind and starting all
+This Docker Compose configuration serves the purpose of building and starting all
 the essential Docker containers required to facilitate the local development of both the website
 and the UI bundle. This configuration orchestrates this by starting multiple containers
 simultaneously. Each container within this Compose configuration corresponds to a distinct
@@ -29,16 +29,15 @@ component or service of the development environment.
 | Serve the static HTML template files, which form the foundation of the UI bundle (and hence the whole website UI) through an Apache webserver.
 |===
 
+=== Prerequisites
+
+This compose config has been developed and tested with Docker version 24.0.2 on top of
+Ubuntu 22.10.
+
 == How to Use
 
-Make sure to control the image builds and containers by using the
-xref:AUTO-GENERATED:Makefile.adoc[Makefile]. The `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip`
-is a mandatory prerequisite (which the Makefile ensures). Otherwise the build breaks due to a
+Make sure to control the image builds and containers by using the xref:AUTO-GENERATED:Makefile.adoc[Makefile].
+
+The `make ui/material-admin-pro/ui-bundle/build/ui-bundle.zip` is a mandatory prerequisite
+(which the Makefile ensures). Otherwise the build breaks due to a
 missing UI bundle.
-
-See xref:AUTO-GENERATED:Makefile.adoc[Makefile]
-
-== Prerequisites
-
-This compose config has been developed and tested with Docker version 24.0.2 on top
-of Ubuntu 22.10.

--- a/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
@@ -15,4 +15,6 @@ This image has been developed and tested with Docker version 24.0.7 on top of Ub
 
 == See also
 
+* xref:AUTO-GENERATED:Makefile.adoc[Makefile]
+* xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]
 * xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]

--- a/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
@@ -1,0 +1,18 @@
+= Dockerfile
+
+Local development image which provides the preview for the UI bundle.
+
+== Overview
+
+This Dockerfile is used for local development purposes only. Despite being
+build and tested via a GitHub Actions workflow, it is never published to DockerHub. It
+remains confined to local usage. This particular Dockerfile is providing the preview for
+the UI bundle, enabling convenient development by running `gulp preview`.
+
+== Prerequisites
+
+This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+
+== See also
+
+* xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]

--- a/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/pages/ui/material-admin-pro/ui-bundle/Dockerfile.adoc
@@ -9,7 +9,7 @@ build and tested via a GitHub Actions workflow, it is never published to DockerH
 remains confined to local usage. This particular Dockerfile is providing the preview for
 the UI bundle, enabling convenient development by running `gulp preview`.
 
-== Prerequisites
+=== Prerequisites
 
 This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 

--- a/docs/modules/AUTO-GENERATED/partials/nav-docker-compose.adoc
+++ b/docs/modules/AUTO-GENERATED/partials/nav-docker-compose.adoc
@@ -1,0 +1,1 @@
+* xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]

--- a/docs/modules/AUTO-GENERATED/partials/nav-dockerfile.adoc
+++ b/docs/modules/AUTO-GENERATED/partials/nav-dockerfile.adoc
@@ -1,2 +1,3 @@
 * xref:AUTO-GENERATED:-devcontainer/Dockerfile.adoc[.devcontainer/Dockerfile]
+* xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]
 * xref:AUTO-GENERATED:Dockerfile.adoc[Dockerfile]

--- a/ui/material-admin-pro/ui-bundle/.gitignore
+++ b/ui/material-admin-pro/ui-bundle/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /node_modules/
 /public/
+/src/font/

--- a/ui/material-admin-pro/ui-bundle/Dockerfile
+++ b/ui/material-admin-pro/ui-bundle/Dockerfile
@@ -12,6 +12,8 @@
 #
 # == See also
 #
+# * xref:AUTO-GENERATED:Makefile.adoc[Makefile]
+# * xref:AUTO-GENERATED:ui/material-admin-pro/ui-bundle/Dockerfile.adoc[ui/material-admin-pro/ui-bundle/Dockerfile]
 # * xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]
 
 

--- a/ui/material-admin-pro/ui-bundle/Dockerfile
+++ b/ui/material-admin-pro/ui-bundle/Dockerfile
@@ -6,7 +6,7 @@
 # remains confined to local usage. This particular Dockerfile is providing the preview for
 # the UI bundle, enabling convenient development by running ``gulp preview``.
 #
-# == Prerequisites
+# === Prerequisites
 #
 # This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
 #

--- a/ui/material-admin-pro/ui-bundle/Dockerfile
+++ b/ui/material-admin-pro/ui-bundle/Dockerfile
@@ -1,0 +1,28 @@
+# @file Dockerfile
+# @brief Local development image which provides the preview for the UI bundle.
+#
+# @description This Dockerfile is used for local development purposes only. Despite being
+# build and tested via a GitHub Actions workflow, it is never published to DockerHub. It
+# remains confined to local usage. This particular Dockerfile is providing the preview for
+# the UI bundle, enabling convenient development by running ``gulp preview``.
+#
+# == Prerequisites
+#
+# This image has been developed and tested with Docker version 24.0.7 on top of Ubuntu 23.10.
+#
+# == See also
+#
+# * xref:AUTO-GENERATED:docker-compose-yml.adoc[docker-compose.yml]
+
+
+FROM node:21.4.0-bookworm-slim
+LABEL maintainer="sebastian@sommerfeld.io"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN mkdir -p /ui-bundle \
+    && yarn global add gulp-cli@2.3.0
+
+WORKDIR /ui-bundle
+
+ENTRYPOINT ["gulp"]
+CMD ["preview"]


### PR DESCRIPTION
This pull request brings about alterations to the build process, notably shifting the control of Docker containers from the Makefile to Docker Compose. Previously, the Makefile held authority over the Docker containers, managing their orchestration alongside installing dependencies and constructing the UI bundle.

However, with these changes, the Makefile's role has changed It now focuses on handling dependency installation and the building of the UI bundle, leaving the management of Docker containers to a Docker Compose configuration. The Makefile now delegates the responsibility of starting the containers to Docker Compose, streamlining the process and separating concerns between different aspects of the project's workflow.